### PR TITLE
charm lib: Connect all prometheus exporter plugs

### DIFF
--- a/src/layer.yaml
+++ b/src/layer.yaml
@@ -23,10 +23,9 @@ options:
         - ['prometheus-ovn-exporter:network-observe', ':network-observe']
         - ['prometheus-ovn-exporter:openvswitch', ':openvswitch']
         - ['prometheus-ovn-exporter:system-observe', ':system-observe']
-        # NOTE(dmitriis): uncomment those once the snap upload is approved.
-        # - ['prometheus-ovn-exporter:etc-openvswitch', ':system-files']
-        # - ['prometheus-ovn-exporter:run-openvswitch', ':system-files']
-        # - ['prometheus-ovn-exporter:run-ovn', ':system-files']
+        - ['prometheus-ovn-exporter:etc-openvswitch', ':system-files']
+        - ['prometheus-ovn-exporter:run-openvswitch', ':system-files']
+        - ['prometheus-ovn-exporter:run-ovn', ':system-files']
 repo: https://opendev.org/x/charm-ovn-central
 config:
   deletes:

--- a/src/lib/charm/openstack/ovn_central.py
+++ b/src/lib/charm/openstack/ovn_central.py
@@ -124,6 +124,7 @@ class BaseOVNCentralCharm(charms_openstack.charm.OpenStackCharm):
     source_config_key = 'source'
     min_election_timer = 1
     max_election_timer = 60
+    exporter_service = 'snap.prometheus-ovn-exporter.ovn-exporter'
 
     def __init__(self, **kwargs):
         """Override class init to populate restart map with instance method."""
@@ -854,6 +855,7 @@ class BaseOVNCentralCharm(charms_openstack.charm.OpenStackCharm):
 
     def assess_exporter(self):
         is_installed = snap.is_installed('prometheus-ovn-exporter')
+        fresh_install = False
         channel = None
         channel = self.options.ovn_exporter_snap_channel
         if channel is None:
@@ -865,7 +867,19 @@ class BaseOVNCentralCharm(charms_openstack.charm.OpenStackCharm):
             snap.refresh('prometheus-ovn-exporter', channel=channel)
         else:
             snap.install('prometheus-ovn-exporter', channel=channel)
+            fresh_install = True
         snap.connect_all()
+
+        # Note(mkalcok): After the plugs of the exporter snap are connected
+        # for the first time (on snap install), we need to restart
+        # the exporter service for the new permissions to take effect.
+        # The snap can also be installed by the snap layer, so we utilize
+        # additional flag to signal whether we already restarted the service.
+        not_initialized = not reactive.is_flag_set(
+            'prometheus-ovn-exporter.initialized')
+        if fresh_install or not_initialized:
+            ch_core.host.service_restart(self.exporter_service)
+            reactive.set_flag('prometheus-ovn-exporter.initialized')
 
     @staticmethod
     def leave_cluster():

--- a/unit_tests/test_lib_charms_ovn_central.py
+++ b/unit_tests/test_lib_charms_ovn_central.py
@@ -671,13 +671,21 @@ class TestOVNCentralCharm(Helper):
         self.patch_object(ovn_central.snap, 'install')
         self.patch_object(ovn_central.snap, 'remove')
         self.patch_object(ovn_central.snap, 'refresh')
+        self.patch_object(ovn_central.ch_core.host, 'service_restart')
+        self.patch_object(ovn_central.reactive, 'is_flag_set')
+        self.patch_object(ovn_central.reactive, 'set_flag')
 
         self.is_installed.return_value = True
+        self.is_flag_set.return_value = False
 
         self.target.assess_exporter()
         self.remove.assert_called_once_with('prometheus-ovn-exporter')
         self.install.assert_not_called()
         self.refresh.assert_not_called()
+
+        # Don't initialize exporter if it was removed
+        self.service_restart.assert_not_called()
+        self.set_flag.assert_not_called()
 
     def test_assess_exporter_no_channel_not_installed(self):
         self.patch_object(
@@ -689,15 +697,23 @@ class TestOVNCentralCharm(Helper):
         self.patch_object(ovn_central.snap, 'install')
         self.patch_object(ovn_central.snap, 'remove')
         self.patch_object(ovn_central.snap, 'refresh')
+        self.patch_object(ovn_central.ch_core.host, 'service_restart')
+        self.patch_object(ovn_central.reactive, 'is_flag_set')
+        self.patch_object(ovn_central.reactive, 'set_flag')
 
         self.is_installed.return_value = False
+        self.is_flag_set.return_value = False
 
         self.target.assess_exporter()
         self.install.assert_not_called()
         self.refresh.assert_not_called()
         self.remove.assert_not_called()
 
-    def test_assess_exporter_fresh_install(self):
+        # Don't initialize exporter if it is not installed
+        self.service_restart.assert_not_called()
+        self.set_flag.assert_not_called()
+
+    def test_assess_exporter_fresh_install_initialized(self):
         self.patch_object(
             ovn_central.ch_core.hookenv,
             'config',
@@ -706,8 +722,12 @@ class TestOVNCentralCharm(Helper):
         self.patch_object(ovn_central.snap, 'install')
         self.patch_object(ovn_central.snap, 'remove')
         self.patch_object(ovn_central.snap, 'refresh')
+        self.patch_object(ovn_central.ch_core.host, 'service_restart')
+        self.patch_object(ovn_central.reactive, 'is_flag_set')
+        self.patch_object(ovn_central.reactive, 'set_flag')
 
         self.is_installed.return_value = False
+        self.is_flag_set.return_value = True
 
         self.target.assess_exporter()
 
@@ -717,7 +737,14 @@ class TestOVNCentralCharm(Helper):
         self.remove.assert_not_called()
         self.refresh.assert_not_called()
 
-    def test_assess_exporter_refresh(self):
+        # Always initialized exporter on fresh install, even if the flag
+        # was already set.
+        self.service_restart.assert_called_once_with(
+            self.target.exporter_service)
+        self.set_flag.assert_called_once_with(
+            'prometheus-ovn-exporter.initialized')
+
+    def test_assess_exporter_refresh_initialized(self):
         self.patch_object(
             ovn_central.ch_core.hookenv,
             'config',
@@ -727,8 +754,12 @@ class TestOVNCentralCharm(Helper):
         self.patch_object(ovn_central.snap, 'install')
         self.patch_object(ovn_central.snap, 'remove')
         self.patch_object(ovn_central.snap, 'refresh')
+        self.patch_object(ovn_central.ch_core.host, 'service_restart')
+        self.patch_object(ovn_central.reactive, 'is_flag_set')
+        self.patch_object(ovn_central.reactive, 'set_flag')
 
         self.is_installed.return_value = True
+        self.is_flag_set.return_value = True
 
         self.target.assess_exporter()
 
@@ -737,6 +768,41 @@ class TestOVNCentralCharm(Helper):
             channel='stable')
         self.install.assert_not_called()
         self.remove.assert_not_called()
+
+        # Don't initialize exporter on refresh if it was already initialized
+        self.service_restart.assert_not_called()
+        self.set_flag.assert_not_called()
+
+    def test_assess_exporter_refresh_not_initialized(self):
+        self.patch_object(
+            ovn_central.ch_core.hookenv,
+            'config',
+            return_value={'ovn-exporter-channel': 'stable'})
+
+        self.patch_object(ovn_central.snap, 'is_installed')
+        self.patch_object(ovn_central.snap, 'install')
+        self.patch_object(ovn_central.snap, 'remove')
+        self.patch_object(ovn_central.snap, 'refresh')
+        self.patch_object(ovn_central.ch_core.host, 'service_restart')
+        self.patch_object(ovn_central.reactive, 'is_flag_set')
+        self.patch_object(ovn_central.reactive, 'set_flag')
+
+        self.is_installed.return_value = True
+        self.is_flag_set.return_value = False
+
+        self.target.assess_exporter()
+
+        self.refresh.assert_called_once_with(
+            'prometheus-ovn-exporter',
+            channel='stable')
+        self.install.assert_not_called()
+        self.remove.assert_not_called()
+
+        # Initialize exporter on refresh if it hasn't been already.
+        self.service_restart.assert_called_once_with(
+            self.target.exporter_service)
+        self.set_flag.assert_called_once_with(
+            'prometheus-ovn-exporter.initialized')
 
     def test_cluster_leave_ok(self):
         """Test successfully leaving OVN cluster."""


### PR DESCRIPTION
While the prometheus exporter seems to work fine on latest ubuntu release (noble) even without these plugs. On older releases it runs but it does not report OVN metrics.

Note1: I have no explanation why the exporter works correctly on noble. On jammy it reports error when trying to connect to OVN sockets, as would be expected since the plugs are not connected.

Note2: The issue has similarities with [this ovs-exporter issue](https://github.com/openstack-charmers/charm-layer-ovn/pull/100). However there's a difference between the two exporters behavior. While the ovs-exporter stops/crashes if it can't connect to openvswitch socket, ovn-exporter keeps running but reports only basic metrics that don't need connection to OVN sockets. Therefore the approach to solving the issue is slightly different.