### PR TITLE
[stable/24.03] Ensure juju displays errmsg from SSL issues

### DIFF
--- a/src/lib/charm/openstack/ovn_central.py
+++ b/src/lib/charm/openstack/ovn_central.py
@@ -18,6 +18,8 @@ import os
 import subprocess
 import time
 
+from ssl import SSLCertVerificationError
+
 import charmhelpers.core as ch_core
 from charmhelpers.core.host import rsync, write_file
 import charmhelpers.contrib.charmsupport.nrpe as nrpe
@@ -401,9 +403,12 @@ class BaseOVNCentralCharm(charms_openstack.charm.OpenStackCharm):
                                                  'cert_host'),
                                     os.path.join(self.ovn_sysconfdir(),
                                                  'ovn-central.crt'))
-        return os_utils.ows_check_services_running(services=_services,
-                                                   ports=_ports,
-                                                   ssl_check_info=ssl_info)
+        try:
+            return os_utils.ows_check_services_running(services=_services,
+                                                       ports=_ports,
+                                                       ssl_check_info=ssl_info)
+        except SSLCertVerificationError as e:
+            return ("blocked", "Certificate Issue: {}".format(e.strerror))
 
     def custom_assess_status_last_check(self):
         """Customize charm status output.

--- a/src/tests/tests.yaml
+++ b/src/tests/tests.yaml
@@ -36,6 +36,7 @@ tests:
 - zaza.openstack.charm_tests.ovn.tests.CentralCharmOperationTest
 - zaza.openstack.charm_tests.ovn.tests.CentralCosIntegrationTest
 - zaza.openstack.charm_tests.ovn.tests.OVNCentralDownscaleTests
+- zaza.openstack.charm_tests.ovn.tests.OVNCentralSSLExpireTests
 
 tests_options:
   force_deploy:


### PR DESCRIPTION
There are times when the certificate expires, and the charm goes into error state. This change ensures the right message is displayed, and the right actions can be taken. In errored state the vault reissue action doesn't work, this update would allow for the certs to be updated as the charm is not in error state.

Func-test-pr: https://github.com/openstack-charmers/zaza-openstack-tests/pull/1332